### PR TITLE
chore: Mejora de configuración Keycloak y uso de .env en Docker

### DIFF
--- a/src/DatosPacientes/Program.cs
+++ b/src/DatosPacientes/Program.cs
@@ -19,14 +19,16 @@ builder.Configuration
     .AddJsonFile("secrets.json", optional: true, reloadOnChange: true)
     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
 
+// Configuración de Keycloak
+var keycloakAuthority = builder.Configuration["KEYCLOAK_AUTHORITY"]
+    ?? builder.Configuration["Keycloak:Authority"]
+    ?? "http://192.168.1.18/realms/myrealm";
 
-var keycloakAuthority = builder.Configuration["Keycloak:Authority"]
-    ?? "http://192.168.1.18:8080/realms/myrealm";
 
-var keycloakAudience = builder.Configuration["Keycloak:Audience"] ?? "account";
-var keycloakClientId = builder.Configuration["Keycloak:ClientId"] ?? "api-pacientes";
-var keycloakClientSecret = builder.Configuration["Keycloak:ClientSecret"];
-var requireHttps = builder.Configuration.GetValue<bool>("Keycloak:RequireHttpsMetadata");
+var keycloakAudience = builder.Configuration["KEYCLOAK_AUDIENCE"] ?? builder.Configuration["Keycloak:Audience"] ?? "account";
+var keycloakClientId = builder.Configuration["KEYCLOAK_CLIENTID"] ?? builder.Configuration["Keycloak:ClientId"] ?? "api-pacientes";
+var keycloakClientSecret = builder.Configuration["KEYCLOAK_CLIENTSECRET"] ?? builder.Configuration["Keycloak:ClientSecret"];
+var requireHttps = builder.Configuration.GetValue<bool>("KEYCLOAK_REQUIREHTTPSMETADATA") || builder.Configuration.GetValue<bool>("Keycloak:RequireHttpsMetadata");
 
 // Add services to the container.
 builder.Services.AddControllers()

--- a/src/DatosPacientes/docker-compose.yml
+++ b/src/DatosPacientes/docker-compose.yml
@@ -2,19 +2,13 @@ services:
   api-pacientes:
     container_name: api-pacientes
     image: datospacientes-api:latest
+    env_file:
+      - .env
     build:
       context: .
       dockerfile: Dockerfile
     networks:
       - pacientes-net
-    environment:
-      - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
-      - ConnectionStrings__cnDatabase=${DB_CONNECTION_STRING}
-      - Keycloak__Authority=${KEYCLOAK_AUTHORITY}
-      - Keycloak__Audience=${KEYCLOAK_AUDIENCE}
-      - Keycloak__ClientId=${KEYCLOAK_CLIENTID}
-      - Keycloak__ClientSecret=${KEYCLOAK_CLIENTSECRET}
-      - Keycloak__RequireHttpsMetadata=${KEYCLOAK_REQUIREHTTPSMETADATA}
     ports:
       - "8081:8080"
     volumes:
@@ -26,4 +20,4 @@ networks:
     driver: bridge
 
 volumes:
-  dp-keys:
+   dp-keys:


### PR DESCRIPTION
Se permite la lectura de variables Keycloak desde entorno o configuración, aumentando la flexibilidad. Se reemplaza la sección environment en docker-compose.yml por env_file (.env) y se corrige la declaración del volumen dp-keys.