### PR TITLE
chore: Actualiza configuración de Keycloak y Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Crea un archivo llamado `.env` en la raíz del backend (o donde corras docker-co
 
 ```env
 ASPNETCORE_ENVIRONMENT=Production
-DB_CONNECTION_STRING=Server=tu-servidor;Database=RecepcionV2;User Id=tu-usuario;Password=tu-password;TrustServerCertificate=True;
+ConnectionStrings__cnDatabase=Server=tu-servidor;Database=RecepcionV2;User Id=tu-usuario;Password=tu-password;TrustServerCertificate=True;
 KEYCLOAK_AUTHORITY=https://tu-servidor-keycloak/realms/tu-realm
 KEYCLOAK_AUDIENCE=tu-audience
 KEYCLOAK_CLIENTID=tu-client-id

--- a/src/DatosPacientes/Program.cs
+++ b/src/DatosPacientes/Program.cs
@@ -138,7 +138,17 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(options =>
+    {
+        // Pre-rellena el client_id y client_secret en la UI de Swagger
+        options.OAuthClientId(keycloakClientId);
+        if (!string.IsNullOrEmpty(keycloakClientSecret))
+        {
+            options.OAuthClientSecret(keycloakClientSecret);
+        }
+        options.OAuthAppName("Swagger UI - Datos Pacientes");
+         options.OAuthUsePkce();
+    });
 }
 
 // Comentado para usar solo HTTP en el contenedor y evitar la advertencia de redirección HTTPS

--- a/src/DatosPacientes/appsettings.json
+++ b/src/DatosPacientes/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "Keycloak": {
-    "Authority": "http://192.168.1.18:8090/realms/myrealm",
+    "Authority": "http://192.168.1.18/realms/myrealm",
     "Audience": "api-pacientes"
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Se ajusta el README.md para usar `ConnectionStrings__cnDatabase` en el archivo `.env`. Se mejora la integración de Swagger UI con Keycloak pre-rellenando credenciales y habilitando PKCE. Se actualiza la URL de autoridad de Keycloak en appsettings.json eliminando el puerto 8090.